### PR TITLE
Implement zoom and text alignment in preview widget

### DIFF
--- a/minimal_codebase/components/pdf_preview_widget.py
+++ b/minimal_codebase/components/pdf_preview_widget.py
@@ -5,9 +5,25 @@
 PDFプレビュー用のウィジェット
 """
 
-from PyQt6.QtWidgets import QWidget, QMessageBox, QMenu, QInputDialog, QLineEdit, QFontDialog, QFileDialog
+from PyQt6.QtWidgets import (
+    QWidget,
+    QMessageBox,
+    QMenu,
+    QInputDialog,
+    QLineEdit,
+    QFontDialog,
+    QFileDialog,
+)
 from PyQt6.QtCore import Qt, QRect, QPoint, QThreadPool, QRunnable, pyqtSignal, QObject
-from PyQt6.QtGui import QPixmap, QImage, QPainter, QPen, QColor, QFont, QFontMetrics
+from PyQt6.QtGui import (
+    QPixmap,
+    QImage,
+    QPainter,
+    QPen,
+    QColor,
+    QFont,
+    QFontMetrics,
+)
 from PyQt6.QtPrintSupport import QPrinter, QPrintDialog
 import fitz
 import os
@@ -39,7 +55,10 @@ class PDFPreviewWidget(QWidget):
         self.pdf_path = None
         self.doc = None
         self.pixmap = None  # 原寸画像
-        self.overlay_texts = []  # (QRect, str, font)
+        # overlay_textsは原寸(100%)座標で保持する
+        # 各要素は (QRect, str, QFont, Qt.AlignmentFlag)
+        self.overlay_texts = []
+        self.scale_factor = 1.0
         # --- 矩形選択用 ---
         self.selecting = False
         self.selection_rect = QRect()
@@ -50,6 +69,44 @@ class PDFPreviewWidget(QWidget):
         self._selected_overlay = None  # 選択中のテキストボックスindex
         self._drag_offset = QPoint()
         self.thread_pool = QThreadPool()
+
+    def set_scale(self, scale: float):
+        """表示倍率を設定 (1.0 = 100%)"""
+        if not self.pixmap:
+            self.scale_factor = scale
+            return
+        old_scale = self.scale_factor
+        if abs(scale - old_scale) < 0.001:
+            return
+        ratio = scale / old_scale
+        # 選択範囲も倍率に合わせて変換
+        def _scale_rect(rect: QRect) -> QRect:
+            return QRect(
+                int(rect.x() * ratio),
+                int(rect.y() * ratio),
+                int(rect.width() * ratio),
+                int(rect.height() * ratio),
+            )
+
+        if self.selection_rect.isValid() and not self.selection_rect.isNull():
+            self.selection_rect = _scale_rect(self.selection_rect)
+            self.selection_start = QPoint(
+                int(self.selection_start.x() * ratio),
+                int(self.selection_start.y() * ratio),
+            )
+            self.selection_end = QPoint(
+                int(self.selection_end.x() * ratio),
+                int(self.selection_end.y() * ratio),
+            )
+        if self._edit_box:
+            box_rect = _scale_rect(self._edit_box.geometry())
+            self._edit_box.setGeometry(box_rect)
+        self.scale_factor = scale
+        self.resize(
+            int(self.pixmap.width() * scale),
+            int(self.pixmap.height() * scale),
+        )
+        self.update()
     
     def set_pdf(self, pdf_path):
         """PDFをセットして表示
@@ -76,8 +133,14 @@ class PDFPreviewWidget(QWidget):
                 pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
                 img = QImage(pix.samples, pix.width, pix.height, pix.stride, QImage.Format.Format_RGB888)
                 self.pixmap = QPixmap.fromImage(img)
-                self.setFixedSize(self.pixmap.size())
-                self.resize(self.pixmap.width(), self.pixmap.height())
+                self.setFixedSize(
+                    int(self.pixmap.width() * self.scale_factor),
+                    int(self.pixmap.height() * self.scale_factor),
+                )
+                self.resize(
+                    int(self.pixmap.width() * self.scale_factor),
+                    int(self.pixmap.height() * self.scale_factor),
+                )
                 self.overlay_texts = []
                 self.selection_rect = QRect()
                 self.update()
@@ -125,21 +188,37 @@ class PDFPreviewWidget(QWidget):
     def paintEvent(self, event):
         painter = QPainter(self)
         if self.pixmap:
-            painter.drawPixmap(0, 0, self.pixmap)
+            scaled = self.pixmap.scaled(
+                int(self.pixmap.width() * self.scale_factor),
+                int(self.pixmap.height() * self.scale_factor),
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+            painter.drawPixmap(0, 0, scaled)
         # 上書きテキスト描画
         for i, item in enumerate(self.overlay_texts):
-            if len(item) == 3:
-                rect, text, font = item
+            if len(item) >= 4:
+                rect_orig, text, font, align = item
+            elif len(item) == 3:
+                rect_orig, text, font = item
+                align = Qt.AlignmentFlag.AlignCenter
             else:
-                rect, text = item
+                rect_orig, text = item
                 font = painter.font()
                 font.setPointSize(16)
+                align = Qt.AlignmentFlag.AlignCenter
+            rect = QRect(
+                int(rect_orig.x() * self.scale_factor),
+                int(rect_orig.y() * self.scale_factor),
+                int(rect_orig.width() * self.scale_factor),
+                int(rect_orig.height() * self.scale_factor),
+            )
             painter.setPen(Qt.PenStyle.NoPen)  # 枠線なし
             painter.setBrush(QColor(255, 255, 255))
             painter.drawRect(rect)
             painter.setPen(QPen(QColor(0, 0, 0)))
             painter.setFont(font)
-            painter.drawText(rect, Qt.AlignmentFlag.AlignCenter, text)
+            painter.drawText(rect, align, text)
             # 選択中のみ薄い枠線を表示
             if i == self._selected_overlay:
                 painter.setPen(QPen(QColor(0, 120, 255, 180), 2, Qt.PenStyle.DashLine))
@@ -156,7 +235,13 @@ class PDFPreviewWidget(QWidget):
         if event.button() == Qt.MouseButton.LeftButton:
             # テキストボックス選択・移動
             for i, item in enumerate(self.overlay_texts):
-                rect = item[0]
+                rect_orig = item[0]
+                rect = QRect(
+                    int(rect_orig.x() * self.scale_factor),
+                    int(rect_orig.y() * self.scale_factor),
+                    int(rect_orig.width() * self.scale_factor),
+                    int(rect_orig.height() * self.scale_factor),
+                )
                 if rect.contains(event.pos()):
                     self._selected_overlay = i
                     self._drag_offset = event.pos() - rect.topLeft()
@@ -173,10 +258,20 @@ class PDFPreviewWidget(QWidget):
             if self._selected_overlay is not None:
                 menu = QMenu(self)
                 font_action = menu.addAction("書体変更")
+                align_menu = menu.addMenu("揃え変更")
+                left_act = align_menu.addAction("左揃え")
+                center_act = align_menu.addAction("中揃え")
+                right_act = align_menu.addAction("右揃え")
                 delete_action = menu.addAction("削除")
                 action = menu.exec(self.mapToGlobal(event.pos()))
                 if action == font_action:
                     self.change_overlay_font(self._selected_overlay)
+                elif action == left_act:
+                    self.change_overlay_alignment(self._selected_overlay, Qt.AlignmentFlag.AlignLeft)
+                elif action == center_act:
+                    self.change_overlay_alignment(self._selected_overlay, Qt.AlignmentFlag.AlignCenter)
+                elif action == right_act:
+                    self.change_overlay_alignment(self._selected_overlay, Qt.AlignmentFlag.AlignRight)
                 elif action == delete_action:
                     self.overlay_texts.pop(self._selected_overlay)
                     self._selected_overlay = None
@@ -187,6 +282,11 @@ class PDFPreviewWidget(QWidget):
             if self.selection_rect.isValid() and not self.selection_rect.isNull():
                 add_text_action = menu.addAction("テキスト追加（サイズ・書体指定）")
                 ocr_action = menu.addAction("選択範囲をOCRして上書き")
+            zoom_menu = menu.addMenu("表示倍率")
+            zoom_actions = {}
+            for p in [100, 90, 80, 70, 60, 50]:
+                act = zoom_menu.addAction(f"{p}%")
+                zoom_actions[act] = p
             save_action = menu.addAction("PDFを上書き保存")
             saveas_action = menu.addAction("名前をつけて保存")
             action = menu.exec(self.mapToGlobal(event.pos()))
@@ -195,6 +295,8 @@ class PDFPreviewWidget(QWidget):
                     self.add_text_box_to_selection()
                 elif action == ocr_action:
                     self.ocr_selected_region()
+            if action in zoom_actions:
+                self.set_scale(zoom_actions[action] / 100.0)
             if action == save_action:
                 self.save_pdf(overwrite=True)
             elif action == saveas_action:
@@ -203,10 +305,16 @@ class PDFPreviewWidget(QWidget):
     def mouseMoveEvent(self, event):
         if self._selected_overlay is not None and event.buttons() & Qt.MouseButton.LeftButton:
             # テキストボックス移動
-            rect, text, font = self.overlay_texts[self._selected_overlay]
-            new_topleft = event.pos() - self._drag_offset
-            new_rect = QRect(new_topleft, rect.size())
-            self.overlay_texts[self._selected_overlay] = (new_rect, text, font)
+            item = self.overlay_texts[self._selected_overlay]
+            if len(item) >= 4:
+                rect_orig, text, font, align = item
+            else:
+                rect_orig, text, font = item
+                align = Qt.AlignmentFlag.AlignCenter
+            new_x = (event.pos().x() - self._drag_offset.x()) / self.scale_factor
+            new_y = (event.pos().y() - self._drag_offset.y()) / self.scale_factor
+            new_rect = QRect(int(new_x), int(new_y), rect_orig.width(), rect_orig.height())
+            self.overlay_texts[self._selected_overlay] = (new_rect, text, font, align)
             self.update()
             return
         if self.selecting:
@@ -304,7 +412,13 @@ class PDFPreviewWidget(QWidget):
         # 既存の重ねテキストを消す
         self.overlay_texts = []
         # テキストボックスをOCRボックス範囲に合わせて重ねる
-        self.overlay_texts.append((QRect(x, y, w, h), new_text))
+        rect_orig = QRect(
+            int(x / self.scale_factor),
+            int(y / self.scale_factor),
+            int(w / self.scale_factor),
+            int(h / self.scale_factor),
+        )
+        self.overlay_texts.append((rect_orig, new_text, QFont(), Qt.AlignmentFlag.AlignCenter))
         self.update()
         # TODO: OCR JSONへの上書き保存処理を後続で実装 
 
@@ -330,7 +444,13 @@ class PDFPreviewWidget(QWidget):
     def apply_edit_box_text(self, edit):
         text = edit.text()
         rect = edit.geometry()
-        self.overlay_texts.append((rect, text))
+        rect_orig = QRect(
+            int(rect.x() / self.scale_factor),
+            int(rect.y() / self.scale_factor),
+            int(rect.width() / self.scale_factor),
+            int(rect.height() / self.scale_factor),
+        )
+        self.overlay_texts.append((rect_orig, text, edit.font(), edit.alignment()))
         edit.deleteLater()
         self._edit_box = None
         self.update()
@@ -351,16 +471,44 @@ class PDFPreviewWidget(QWidget):
         metrics = QFontMetrics(font)
         text_width = metrics.horizontalAdvance(text)
         text_height = metrics.height()
-        rect = QRect(sel)
+        rect = QRect(
+            int(sel.x() / self.scale_factor),
+            int(sel.y() / self.scale_factor),
+            int(sel.width() / self.scale_factor),
+            int(sel.height() / self.scale_factor),
+        )
         if text_width > rect.width():
             rect.setWidth(text_width + 12)  # 余白
         if text_height > rect.height():
             rect.setHeight(text_height + 8)
-        self.overlay_texts.append((rect, text, font))
+        align_items = ["左揃え", "中揃え", "右揃え"]
+        align_map = {
+            "左揃え": Qt.AlignmentFlag.AlignLeft,
+            "中揃え": Qt.AlignmentFlag.AlignCenter,
+            "右揃え": Qt.AlignmentFlag.AlignRight,
+        }
+        align_txt, ok = QInputDialog.getItem(
+            self,
+            "文字揃え選択",
+            "揃えを選択:",
+            align_items,
+            1,
+            False,
+        )
+        if not ok:
+            align = Qt.AlignmentFlag.AlignCenter
+        else:
+            align = align_map.get(align_txt, Qt.AlignmentFlag.AlignCenter)
+        self.overlay_texts.append((rect, text, font, align))
         self.update()
 
     def change_overlay_font(self, idx):
-        rect, text, font = self.overlay_texts[idx]
+        item = self.overlay_texts[idx]
+        if len(item) >= 4:
+            rect, text, font, align = item
+        else:
+            rect, text, font = item
+            align = Qt.AlignmentFlag.AlignCenter
         new_font, ok = QFontDialog.getFont(font, self, "書体とサイズを変更")
         if not ok:
             return
@@ -373,7 +521,35 @@ class PDFPreviewWidget(QWidget):
             new_rect.setWidth(text_width + 12)
         if text_height > new_rect.height():
             new_rect.setHeight(text_height + 8)
-        self.overlay_texts[idx] = (new_rect, text, new_font)
+        align_items = ["左揃え", "中揃え", "右揃え"]
+        align_map = {
+            "左揃え": Qt.AlignmentFlag.AlignLeft,
+            "中揃え": Qt.AlignmentFlag.AlignCenter,
+            "右揃え": Qt.AlignmentFlag.AlignRight,
+        }
+        align_txt, ok = QInputDialog.getItem(
+            self,
+            "文字揃え選択",
+            "揃えを選択:",
+            align_items,
+            align_items.index("中揃え"),
+            False,
+        )
+        if ok:
+            align = align_map.get(align_txt, align)
+        self.overlay_texts[idx] = (new_rect, text, new_font, align)
+        self.update()
+
+    def change_overlay_alignment(self, idx, align):
+        item = self.overlay_texts[idx]
+        if len(item) >= 4:
+            rect, text, font, _ = item
+        elif len(item) == 3:
+            rect, text, font = item
+        else:
+            rect, text = item
+            font = QFont()
+        self.overlay_texts[idx] = (rect, text, font, align)
         self.update()
 
     def save_pdf(self, overwrite=False):
@@ -384,18 +560,22 @@ class PDFPreviewWidget(QWidget):
         img = self.pixmap.toImage()
         painter = QPainter(img)
         for item in self.overlay_texts:
-            if len(item) == 3:
+            if len(item) >= 4:
+                rect, text, font, align = item
+            elif len(item) == 3:
                 rect, text, font = item
+                align = Qt.AlignmentFlag.AlignCenter
             else:
                 rect, text = item
                 font = painter.font()
                 font.setPointSize(16)
+                align = Qt.AlignmentFlag.AlignCenter
             painter.setPen(Qt.PenStyle.NoPen)  # 枠線なし
             painter.setBrush(QColor(255, 255, 255))
             painter.drawRect(rect)
             painter.setPen(QPen(QColor(0, 0, 0)))
             painter.setFont(font)
-            painter.drawText(rect, Qt.AlignmentFlag.AlignCenter, text)
+            painter.drawText(rect, align, text)
         painter.end()
         # 一時PNG保存
         import tempfile


### PR DESCRIPTION
## Summary
- add scale control to `PDFPreviewWidget`
- allow text alignment selection for overlays
- include zoom actions in context menu
- adjust overlay handling for scaling

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6842884d4ac88320819047d281a61b32