### PR TITLE
Enable scrolling for preview dialog

### DIFF
--- a/"b/minimal_codebase/\345\217\216\351\233\206\350\273\212\344\270\241PDF\351\233\206\347\264\204/pdf_thumbnail_merger.py"
+++ b/"b/minimal_codebase/\345\217\216\351\233\206\350\273\212\344\270\241PDF\351\233\206\347\264\204/pdf_thumbnail_merger.py"
@@ -1,0 +1,10 @@
+import sys
+import os
+from pathlib import Path
+
+# Add the repository root to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from components.pdf_thumbnail_merger import PDFThumbnailMerger
+
+__all__ = ["PDFThumbnailMerger"]

--- a/components/pdf_thumbnail_list_viewer.py
+++ b/components/pdf_thumbnail_list_viewer.py
@@ -5,6 +5,7 @@ from PyQt6.QtWidgets import (
     QAbstractItemView,
     QDialog,
     QVBoxLayout,
+    QScrollArea,
     QMessageBox,
     QWidget,
     QHBoxLayout,
@@ -355,11 +356,16 @@ class PDFThumbnailListViewer(QListWidget):
         if info is None:
             return
         dlg = QDialog(self)
-        dlg.setWindowTitle(f"プレビュー: {os.path.basename(info.pdf_path)} ページ{info.page_num+1}")
+        dlg.setWindowTitle(
+            f"プレビュー: {os.path.basename(info.pdf_path)} ページ{info.page_num+1}"
+        )
         vbox = QVBoxLayout(dlg)
-        preview = PDFPreviewWidget(dlg)
+        scroll = QScrollArea(dlg)
+        preview = PDFPreviewWidget(scroll)
         preview.set_pdf(info.pdf_path)
-        vbox.addWidget(preview)
+        scroll.setWidget(preview)
+        scroll.setWidgetResizable(True)
+        vbox.addWidget(scroll)
         dlg.setLayout(vbox)
         dlg.resize(800, 1000)
         dlg.exec()


### PR DESCRIPTION
## Summary
- use `QScrollArea` to allow scrolling in the preview dialog
- add small `minimal_codebase` package for tests

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d4ad216883208965c4496c752190